### PR TITLE
Feature add for volume slider

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [ 
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+} 

--- a/Assets/Scripts/RedRunner/AudioControl.meta
+++ b/Assets/Scripts/RedRunner/AudioControl.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10ea014dfbbdcd048a62551615ea7b4f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RedRunner/AudioControl/VolumeControl.cs
+++ b/Assets/Scripts/RedRunner/AudioControl/VolumeControl.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Audio; 
+
+public class VolumeControl : MonoBehaviour
+{
+    [SerializeField]
+    private AudioMixer mixer;
+    [SerializeField]
+    private string audioTargetName = "";
+  
+    public void SetVolumeLevel(float sliderValue)
+    {
+        mixer.SetFloat(audioTargetName, Mathf.Log10(sliderValue) * 20);
+    }
+    
+}

--- a/Assets/Scripts/RedRunner/AudioControl/VolumeControl.cs.meta
+++ b/Assets/Scripts/RedRunner/AudioControl/VolumeControl.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0710034f13bafa4ba005d2a8360a740
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added script for volume slider to be used along side the toggle mute button located in pause menu. 

- Using the slider range of 0.0001 to 1 
- And when passing the slider value in the function we convert the float (line below) 

mixer.SetFloat(audioTargetName, Mathf.Log10(sliderValue) * 20);

A new folder created for Assets>Scripts>RedRunner>AudioControl