### PR TITLE
Fix: Add missing m_CursorHideDelay variable for Unity 6 compilation

### DIFF
--- a/Assets/Scripts/RedRunner/UIManager.cs
+++ b/Assets/Scripts/RedRunner/UIManager.cs
@@ -37,6 +37,8 @@ namespace RedRunner
 		[SerializeField]
 		private Texture2D m_CursorClickTexture;
 
+        [SerializeField] private float m_CursorHideDelay = 3f;
+
         // The cursor timer, which will keep track of how long the cursor has been inactive
         private float cursorTimer;
         // The cursor position, we will use this to compare the cursor position to check if it has moved.


### PR DESCRIPTION
## Issue
After migrating to Unity 6 (6000.2.6f2), the `m_CursorHideDelay` variable 
was removed from the `UIManager` class but is still referenced on line 132, 
causing `CS0103` compilation error.

## Solution
Added the missing variable declaration with default value (3 seconds):
```csharp
[SerializeField] private float m_CursorHideDelay = 3f;